### PR TITLE
Add `derive(Clone)` to WeightMatrix

### DIFF
--- a/src/weight_matrix.rs
+++ b/src/weight_matrix.rs
@@ -1,6 +1,6 @@
 use crate::{Position, SquareMatrix, WeightNum, Weights};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WeightMatrix<T: WeightNum> {
     c: SquareMatrix<T>,
 }


### PR DESCRIPTION
Is any particular reason why WeightMatrix may not clonable?